### PR TITLE
Rearrange right column top section

### DIFF
--- a/src/handlebars/index.handlebars
+++ b/src/handlebars/index.handlebars
@@ -3,7 +3,7 @@
 <main class="grey-bg home-main">
   <div class="top-section">
     <div class="content-container">
-        <h1>Prebuilt OpenJDK Binaries for Free!</h1>
+        <h1 class="top-title">Prebuilt OpenJDK Binaries for Free!</h1>
         <p class="intro">
         Java™ is the world's leading programming language and platform.
         The Adoptium Working Group promotes and supports high-quality, TCK certified runtimes and associated technology for use across the Java™ ecosystem.
@@ -32,6 +32,7 @@
     </div>
 
       <div class="content-container">
+        <h1 class="top-title">More download information</h1>
          <a href="./releases.html" class="dl-button dl-thin-button a-button fadeIn invisible" id="dl-other">
           <div class="other-btn">
             <span>Other platforms</span>

--- a/src/handlebars/partials/jdk-selector.handlebars
+++ b/src/handlebars/partials/jdk-selector.handlebars
@@ -1,6 +1,6 @@
 <div class="btn-container">
     <form id="jdk-selector" class="btn-form">
-    <h3>1. Choose a Version</h3>
+    <h3>Choose a Version</h3>
     </form>
     {{!-- <form id="jvm-selector" class="index-jvm-btn-form jvm-btn-form btn-form">
     <h3>2. Choose a Vendor

--- a/src/scss/styles-2-index.scss
+++ b/src/scss/styles-2-index.scss
@@ -33,6 +33,11 @@ main .intro a:hover {
   justify-content: center;
 }
 
+.top-title {
+  margin-top: 1.5rem;
+  margin-bottom: 0.5rem;
+}
+
 #loading-index {
   position: absolute;
   left: 50%;
@@ -47,7 +52,7 @@ a.dl-button {
   background-color: $brighterblue;
   color: $maingrey;
   border-radius: 0.2rem;
-  // width: 20rem;
+  width: 20rem;
   line-height: 5rem;
   font-size: 1.5rem;
   margin: 1.2rem 0.6rem 0 0.6rem;
@@ -80,7 +85,7 @@ a.dl-button:hover {
 }
 
 a.dl-thin-button {
-  line-height: 2rem;
+  line-height: 3.5rem;
   font-size: 1rem;
   background-color: $accentgrey;
   color: $mainblue;


### PR DESCRIPTION
The right column in the top section has a title now and the buttons have been made slightly higher. This brings the content of the column more into alignment with the other two columns.
The top of the three titles is better aligned now as well after changing some CSS.
This is not a separate issue, but part of issue #11 